### PR TITLE
feat(sum): Adds a sum filter

### DIFF
--- a/src/_filter/math/sum.js
+++ b/src/_filter/math/sum.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * @ngdoc filter
+ * @name sum
+ * @kind function
+ *
+ * @description
+ * Sums an array. It can sum an array of primitives, or sum a property or nested property on an array of objects.
+ *
+ */
+angular.module('a8m.math.max', ['a8m.math'])
+
+    .filter('sum', function () {
+        var getValueByPath = function (member, objPath) {
+            // Verify that path was received and that it is a string
+            if (member && objPath && typeof objPath === 'string') {
+                // Breakdown path
+                var pathMembers = objPath.trim().split('.');
+                // If pathMembers has only one member then return the value, else call getValueByPath
+                if (pathMembers.length === 1) {
+                    return parseFloat(member[pathMembers[0]]) || 0;
+                }
+                else {
+                    // member[pathMembers[0]]: Will pass the nested element
+                    // pathMembers.slice(1).join('.'): Will create a new string, like objPath, but without first path member
+                    return getValueByPath(member[pathMembers[0]], pathMembers.slice(1).join('.'));
+                }
+            } else {
+                // Default value to return in case a user has passed bad parameters
+                return 0;
+            }
+        };
+
+
+        return function (input, objPath) {
+            // Declare sum
+            var sum = 0;
+
+            // Determine that input is an array, or else return back the input
+            if (!angular.isArray(input)) {
+                return input;
+            }
+
+            input.forEach(function (member) {
+                // If member is an object then getValueByPath else sum the primitive
+                if (member && member.toString() === '[object Object]') {
+                    sum += getValueByPath(member, objPath);
+                } else {
+                    sum += parseFloat(member) || 0;
+                }
+            });
+
+            return sum;
+        };
+    });

--- a/test/spec/filter/math/sum.js
+++ b/test/spec/filter/math/sum.js
@@ -1,0 +1,224 @@
+'use strict';
+
+describe('sumFilter', function () {
+
+    // load the filter's module
+    beforeEach(module('a8m.math.max'));
+
+    // initialize a new instance of the filter before each test
+    var sum, input, objPath;
+    beforeEach(inject(function ($filter) {
+        sum = $filter('sum');
+    }));
+
+    describe('Passing an array without literal objects', function () {
+        beforeEach(function(){
+            objPath='any.path';
+        });
+        describe('Passing an array of numbers', function () {
+            it('should return the value 10', function () {
+                input = [1,2,3,4];
+                expect(sum(input)).toEqual(10);
+            });
+            it('should return the value 10 and disregard the objPath', function () {
+                input = [1,2,3,4];
+                expect(sum(input, objPath)).toEqual(10);
+            });
+        });
+
+        describe('Passing an array of strings', function () {
+            it('should return the value 10', function () {
+                input = ['1','2','3','4'];
+                expect(sum(input)).toEqual(10);
+            });
+            it('should return the value 10  and disregard the objPath', function () {
+                input = ['1','2','3','4'];
+                expect(sum(input, objPath)).toEqual(10);
+            });
+        });
+
+        describe('Passing a mixed array of strings and numbers', function () {
+            it('should return the value 10', function () {
+                input = ['1',2,'3g',4];
+                expect(sum(input)).toEqual(10);
+            });
+            it('should return the value 10  and disregard the objPath', function () {
+                input = ['1','2','3','4'];
+                expect(sum(input, objPath)).toEqual(10);
+            });
+        });
+
+        describe('Passing a mixed array of strings and numbers and strings that fail parse', function () {
+            it('should return the value 10', function () {
+                input = ['1',2,'3',4, 'foo', 'bar', NaN];
+                expect(sum(input)).toEqual(10);
+            });
+            it('should return the value 10  and disregard the objPath', function () {
+                input = ['1','2','3','4'];
+                expect(sum(input, objPath)).toEqual(10);
+            });
+        });
+
+        describe('Passing an array of mixed types', function () {
+            it('should return the value 10', function () {
+                input = ['1',2,'3',4, 'foo', 'bar', NaN, function(){}, true, false];
+                expect(sum(input)).toEqual(10);
+            });
+            it('should return the value 10  and disregard the objPath', function () {
+                input = ['1','2','3','4'];
+                expect(sum(input, objPath)).toEqual(10);
+            });
+        });
+
+    });
+
+    describe('Passing non arrays', function () {
+
+        describe('Passing a number', function () {
+            it('should return the value 10', function () {
+                input = 10;
+                expect(sum(input)).toEqual(10);
+            });
+        });
+
+        describe('Passing a string', function () {
+            it('should return the value "foo"', function () {
+                input = 'foo';
+                expect(sum(input)).toEqual('foo');
+            });
+        });
+
+        describe('Passing a function', function () {
+            it('should return the function', function () {
+                input = function(){};
+                expect(sum(input)).toEqual(input);
+            });
+        });
+
+        describe('Passing a boolean', function () {
+            it('should return the value false', function () {
+                input = false;
+                expect(sum(input)).toEqual(false);
+            });
+        });
+
+    });
+
+    describe('Passing arrays with literal objects', function () {
+        describe('Passing array with a literal object that has values on the first level', function () {
+            it('should return the value 10', function () {
+                input = [
+                    {value: 1},
+                    {value: 2},
+                    {value: 3},
+                    {value: 4}
+                ];
+                objPath = 'value';
+                expect(sum(input, objPath)).toEqual(10);
+            });
+        });
+        describe('Passing array with a literal object that has mixed values on the first level', function () {
+            it('should return the value 10', function () {
+                input = [
+                    {value: 1},
+                    {value: '2'},
+                    {value: 3},
+                    {value: '4g'},
+                    {value: 'foo'}
+                ];
+                objPath = 'value';
+                expect(sum(input, objPath)).toEqual(10);
+            });
+        });
+        describe('Passing array with a literal object and wrong path', function () {
+            it('should return the value 10', function () {
+                input = [
+                    {value: 1},
+                    {value: 2},
+                    {value: 3},
+                    {value: 4}
+                ];
+                objPath = 'values';
+                expect(sum(input, objPath)).toEqual(0);
+            });
+        });
+        describe('Passing array with a literal object and a path that is too long', function () {
+            it('should return the value 10', function () {
+                input = [
+                    {value: 1},
+                    {value: 2},
+                    {value: 3},
+                    {value: 4}
+                ];
+                objPath = 'values.in.the.object';
+                expect(sum(input, objPath)).toEqual(0);
+            });
+        });
+        describe('Passing array with a literal object and nested objects', function () {
+            it('should return the value 10', function () {
+                input = [
+                    {
+                        name: 'Adanac apple',
+                        inventory: {
+                            amount: 1
+                        }
+                    },
+                    {
+                        name: 'Smith apple',
+                        inventory: {
+                            amount: 2
+                        }
+                    },
+                    {
+                        name: 'Annie apple',
+                        inventory: {
+                            amount: 3
+                        }
+                    },
+                    {
+                        name: 'Pacific apple',
+                        inventory: {
+                            amount: 4
+                        }
+                    }
+                ];
+                objPath = 'inventory.amount';
+                expect(sum(input, objPath)).toEqual(10);
+            });
+        });
+
+        describe('Passing array with a literal object and nested objects and mixed types', function () {
+            it('should return the value 10', function () {
+                input = [
+                    {
+                        name: 'Adanac apple',
+                        inventory: {
+                            amount: 1
+                        }
+                    },
+                    {
+                        name: 'Smith apple',
+                        inventory: {
+                            amount: '2'
+                        }
+                    },
+                    {
+                        name: 'Annie apple',
+                        inventory: {
+                            amount: 3
+                        }
+                    },
+                    {
+                        name: 'Pacific apple',
+                        inventory: {
+                            amount: '4g'
+                        }
+                    }
+                ];
+                objPath = 'inventory.amount';
+                expect(sum(input, objPath)).toEqual(10);
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
This is the sum filter.
Hope you find this good.
If you like it we can use the same principle for statistical functions, for example average etc.

To use with markup:
- array of numbers or parseble variables:
  markup:

```
    {{ array | sum }}
```
- Array of objects with parameters that have numbers or parseble variables:

```
    array = [
                    {
                        name: 'Adanac apple',
                        inventory: {
                            amount: 1
                        }
                    },
                    {
                        name: 'Smith apple',
                        inventory: {
                            amount: 2
                        }
                    },
                    {
                        name: 'Annie apple',
                        inventory: {
                            amount: 3
                        }
                    },
                    {
                        name: 'Pacific apple',
                        inventory: {
                            amount: 4
                        }
                    }
                ]
```

```
markup:
```

```
    {{ array | sum:'inventory.amount' }}
```
