### PR TITLE
Fix bug in where filter with falsy values.

### DIFF
--- a/src/_common.js
+++ b/src/_common.js
@@ -46,7 +46,7 @@ function objectContains(partial, object) {
   var keys = Object.keys(partial);
 
   return keys.map(function(el) {
-    return !(!object[el] || (object[el] != partial[el]));
+    return (object[el] !== undefined) && (object[el] == partial[el]);
   }).indexOf(false) == -1;
 
 }

--- a/test/spec/filter/collection/where.js
+++ b/test/spec/filter/collection/where.js
@@ -13,14 +13,14 @@ describe('whereFilter', function() {
     'array of all elements that have equivalent property values.', function() {
 
     var array = [
-      { id: 1, name: 'ariel' },
-      { id: 2, name: 'baz' },
-      { id: 1, name: 'ariel' },
-      { id: 1, name: 'bar' }
+      { id: 0, name: 'ariel' },
+      { id: 1, name: 'baz' },
+      { id: 0, name: 'ariel' },
+      { id: 0, name: 'bar' }
     ];
 
-    expect(filter(array, { id: 1, name: 'ariel' })).toEqual([array[0], array[2]]);
-    expect(filter(array, { id: 1 })).not.toContain(array[1]);
+    expect(filter(array, { id: 0, name: 'ariel' })).toEqual([array[0], array[2]]);
+    expect(filter(array, { id: 0 })).not.toContain(array[1]);
 
     expect(filter(array, {})).toEqual(array);
 


### PR DESCRIPTION
This fixes a bug in the `afterWhere`, `beforeWhere`, and `where` filters when filtering with a falsy value (e.g. `false`, `0`, `""`, ...).

Specifically, before this fix, the following did not work as expected (it wouldn't print anything):

``` html
<div ng-init="points = [{x:0, y:1}, {x:2, y:4}]">
  <div ng-repeat="p in points | where:{x:0}">
    {{p}}
  </div>
</div>
```

As it is, the fix still doesn't allow filtering using `undefined` (e.g. `x in xs | where:{foo:undefined}`). We could enable this by using strict equality comparison (`object[el] === partial[el]`), but this could break existing scenarios that expect non-strict semantics. I think it's probably fine to simply not support filtering with `undefined`.

As for tests, I've updated an existing spec to test filtering with `0` instead of adding a completely new spec.
