### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,9 @@
   "devDependencies": {
     "angular-mocks": "*"
   },
+  "main":[
+    "./dist/angular-filter.min.js"
+  ],
   "ignore": [
     "node_modules",
     "bower_components",


### PR DESCRIPTION
Missing "main" attribute if used in a workflow that auto injects bower packages.