### PR TITLE
FIX: groupBy breaking under certain conditions

### DIFF
--- a/src/_filter/collection/count-by.js
+++ b/src/_filter/collection/count-by.js
@@ -25,7 +25,7 @@ angular.module('a8m.count-by', [])
       collection.forEach( function( elm ) {
         prop = get(elm);
 
-        if(!result[prop]) {
+        if(!isArray(result[prop])) {
           result[prop] = 0;
         }
 

--- a/src/_filter/collection/group-by.js
+++ b/src/_filter/collection/group-by.js
@@ -33,7 +33,7 @@ angular.module('a8m.group-by', [ 'a8m.filter-watcher' ])
         forEach( collection, function( elm ) {
           prop = getter(elm);
 
-          if(!result[prop]) {
+          if(!isArray(result[prop])) {
             result[prop] = [];
           }
           result[prop].push(elm);

--- a/src/_filter/string/repeat.js
+++ b/src/_filter/string/repeat.js
@@ -30,7 +30,7 @@ angular.module('a8m.repeat', [])
  * @returns {*}
  */
 function strRepeat(str, n, sep) {
-  if(!n) {
+  if(!isNumber(n) || !n) {
     return str;
   }
   return str + sep + strRepeat(str, --n, sep);


### PR DESCRIPTION
The "groupBy" function can be asked to group by property names such as "valueOf", or other properties implicitly defined in the empty object.

Without this check, a new array isn't created (since the value of the property is a function, not null), and when time comes to push the element into the array, the code will throw an error, saying that result.push is undefined.

The other two (countBy, repeat) are just for readabilty