### PR TITLE
fix(contains): find objects

### DIFF
--- a/src/_filter/collection/contains.js
+++ b/src/_filter/collection/contains.js
@@ -22,7 +22,7 @@ function containsFilter($parse) {
       }
 
       return collection.some(function(elm) {
-        return (isObject(elm) || isFunction(expression))
+        return ((isString(expression) && isObject(elm)) || isFunction(expression))
           ? $parse(expression)(elm)
           : elm === expression;
       });

--- a/test/spec/filter/collection/contains.js
+++ b/test/spec/filter/collection/contains.js
@@ -8,6 +8,13 @@ describe('containsFilter', function() {
   beforeEach(inject(function ($filter) {
     filter = $filter('contains');
   }));
+  
+  it('should find elements which are objects', function() {
+    var needle = {};
+    var haystack = [needle];
+    
+    expect(filter(haystack, needle)).toBeTruthy();
+  });
 
   it('should get collection of primitives and use strict comparison(===)', function() {
     expect(filter(['foo', 'bar'], 'bar')).toBeTruthy();


### PR DESCRIPTION
Previously, contains would not be able to handle searches for object instances within the collection, because the element being searched for was incorrectly treated as an expression.
Fixes #182