### PR TITLE
Adds license declaration to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "angular-filter",
   "main": "dist/angular-filter.js",
   "description": "Bunch of useful filters for angularJS(with no external dependencies!)",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/a8m/angular-filter.git"


### PR DESCRIPTION
Adds the chosen license (MIT in this case) to the bower.json.

Fixes #179 