### PR TITLE
shortFmt always returns String when given Number

### DIFF
--- a/src/_filter/math/short-fmt.js
+++ b/src/_filter/math/short-fmt.js
@@ -14,7 +14,7 @@ angular.module('a8m.math.shortFmt', ['a8m.math'])
       if(isNumber(decimal) && isFinite(decimal) && decimal%1===0 && decimal >= 0 &&
         isNumber(number) && isFinite(number)){
         if(number < 1e3) {
-          return number;
+          return '' + number;  // Coerce to string
         } else if(number < 1e6) {
           return convertToDecimal((number / 1e3), decimal, $math) + ' K';
         } else if(number < 1e9){


### PR DESCRIPTION
More specifically, it no longer returns a Number when given a value less than 1000.

This is a fix for #205 
