### PR TITLE
groupBy: If property is undefined or null, do not group it together

### DIFF
--- a/dist/angular-filter.js
+++ b/dist/angular-filter.js
@@ -881,7 +881,12 @@ angular.module('a8m.group-by', [ 'a8m.filter-watcher' ])
         var result = {};
         var prop;
 
-        forEach( collection, function( elm ) {
+        forEach( collection, function( elm, key ) {
+          if ( isUndefined(elm[property]) || elm[property] == null ) {
+            result['_$' + key] = [elm];
+            return;
+          }
+
           prop = getter(elm);
 
           if(!result[prop]) {


### PR DESCRIPTION
Undefined or null implies the property is **not set** meaning do not group it, it is unique.  This uses the key property, prefixed with `_$` to assign it a unique placeholder value and then assign the element itself to that value.

Therefore ng-repeat
```
[
{  "color": "red" },
{  "color": "red" },
{  "color": null }
]
```

Groups into:

```
[{
    "red": [{
        "color": "red"
    }, {
        "color": "red"
    }]
}, {
    "_$3": [{
        "color": null
    }]
}]
```