### PR TITLE
Fix: bower dependency on angular

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/a8m/angular-filter.git"
   },
   "dependencies": {
-    "angular": "1.4.3"
+    "angular": ">=1.4.3"
   },
   "devDependencies": {
     "angular-mocks": "1.4.3"


### PR DESCRIPTION
This fix should avoid unnecessary dependency warning in bower for angular version newer than `1.4.3`.