### PR TITLE
Update version from 0.5.12 to 0.5.14

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "angular-filter",
   "main": "dist/angular-filter.js",
   "description": "Bunch of useful filters for angularJS(with no external dependencies!)",
-  "version": "0.5.12",
+  "version": "0.5.14",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit will avoid the following bower mismatch warning message.

> Version declared in the json (0.5.12) is different than the resolved one (0.5.14)
