### PR TITLE
Fix missing a8m.phoneUS in angular.filter

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -25,6 +25,7 @@ angular.module('angular.filter', [
   'a8m.test',
   'a8m.match',
   'a8m.split',
+  'a8m.phoneUS',
 
   'a8m.to-array',
   'a8m.concat',


### PR DESCRIPTION
'phoneUS' filter was not included into main 'angular.filter' module which causes injection error when entire 'angular.filter' module is included into project. As a result 'phoneUS' does not work as expected.

Console log:
Error: [$injector:unpr] Unknown provider: phoneUSFilterProvider <- phoneUSFilter