### PR TITLE
Whitelist index.js and add 'browser' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "main": "index.js",
   "files": [
     "dist/*.js",
+    "index.js",
     "src"
   ],
+  "browser": "index.js",
   "homepage": "https://github.com/a8m/angular-filter",
   "author": "Ariel Mashraki <ariel@mashraki.co.il>",
   "repository": {


### PR DESCRIPTION
I noticed that I was not able to pull in your project using " import 'angular-filter' ", so I took a peek inside the package.json. I believe this should address the issue.